### PR TITLE
落下中のミノの左右への移動

### DIFF
--- a/src/game/app.js
+++ b/src/game/app.js
@@ -10,7 +10,7 @@ export const GAME_SETTINGS = {
   BLOCK_SIZE: 30,
   ARROW_LEFT: "ArrowLeft",
   ARROW_RIGHT: "ArrowRight",
-  DIERCTION_LEFT: "left",
+  DIRECTION_LEFT: "left",
   DIRECTION_RIGHT: "right",
 };
 
@@ -93,7 +93,7 @@ export class TetrisGame {
     this.arrowRight = GAME_SETTINGS.ARROW_RIGHT;
 
     // テトリスブロックの移動方向
-    this.directionLeft = GAME_SETTINGS.DIERCTION_LEFT;
+    this.directionLeft = GAME_SETTINGS.DIRECTION_LEFT;
     this.directionRight = GAME_SETTINGS.DIRECTION_RIGHT;
   }
 

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -206,10 +206,7 @@ export class TetrisGame {
   moveTetrominoDown() {
     this.yPosition++;
     if (this.isTetrominoAtBottom()) {
-      this.freezeTetromino();
-      this.currentTetromino = this.generateTetromino();
-      this.xPosition = GAME_SETTINGS.START_X_POSITION;
-      this.yPosition = GAME_SETTINGS.START_Y_POSITION;
+      this.freezeAndGenerateTetromino();
     }
   }
 
@@ -234,13 +231,8 @@ export class TetrisGame {
   moveTetrominoLeft() {
     if (!this.isTetrominoAtSides(this.directionLeft)) {
       this.xPosition--;
-
-      // 移動後にブロックが底に到達した場合、ブロックを固定して新しいブロックを生成
       if (this.isTetrominoAtBottom()) {
-        this.freezeTetromino();
-        this.currentTetromino = this.generateTetromino();
-        this.xPosition = GAME_SETTINGS.START_X_POSITION;
-        this.yPosition = GAME_SETTINGS.START_Y_POSITION;
+        this.freezeAndGenerateTetromino();
       }
     }
   }
@@ -252,13 +244,8 @@ export class TetrisGame {
   moveTetrominoRight() {
     if (!this.isTetrominoAtSides(this.directionRight)) {
       this.xPosition++;
-
-      // 移動後にブロックが底に到達した場合、ブロックを固定して新しいブロックを生成
       if (this.isTetrominoAtBottom()) {
-        this.freezeTetromino();
-        this.currentTetromino = this.generateTetromino();
-        this.xPosition = GAME_SETTINGS.START_X_POSITION;
-        this.yPosition = GAME_SETTINGS.START_Y_POSITION;
+        this.freezeAndGenerateTetromino();
       }
     }
   }
@@ -327,5 +314,16 @@ export class TetrisGame {
         }
       }
     }
+  }
+
+  /**
+   * テトリスブロックの固定＆新しいテトリスブロックの生成をまとめて処理する
+   * @returns {void}
+   */
+  freezeAndGenerateTetromino() {
+    this.freezeTetromino();
+    this.currentTetromino = this.generateTetromino();
+    this.xPosition = GAME_SETTINGS.START_X_POSITION;
+    this.yPosition = GAME_SETTINGS.START_Y_POSITION;
   }
 }

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -220,7 +220,7 @@ export class TetrisGame {
    * @returns {void}
    */
   moveTetrominoLeft() {
-    if (this.xPosition > 0 && !this.isTetrominoAtSides("left")) {
+    if (!this.isTetrominoAtSides("left")) {
       this.xPosition--;
     }
   }
@@ -230,11 +230,7 @@ export class TetrisGame {
    * @returns {void}
    */
   moveTetrominoRight() {
-    if (
-      this.xPosition + this.currentTetromino.shape[0].length <
-        GAME_SETTINGS.BOARD_COLUMNS &&
-      !this.isTetrominoAtSides("right")
-    ) {
+    if (!this.isTetrominoAtSides("right")) {
       this.xPosition++;
     }
   }

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -244,15 +244,18 @@ export class TetrisGame {
     for (let row = 0; row < this.currentTetromino.shape.length; row++) {
       for (let col = 0; col < this.currentTetromino.shape[row].length; col++) {
         if (this.currentTetromino.shape[row][col]) {
+          // 移動後のx位置を計算
           const newXPosition =
             direction === "left"
               ? this.xPosition + col - 1
               : this.xPosition + col + 1;
-          if (
-            newXPosition < 0 ||
-            newXPosition >= GAME_SETTINGS.BOARD_COLUMNS ||
-            this.board[this.yPosition + row][newXPosition]
-          ) {
+          // 左右に壁があるかを判定
+          if (newXPosition < 0 || newXPosition >= GAME_SETTINGS.BOARD_COLUMNS) {
+            return true;
+          }
+
+          // 左右にミノがあるかを判定
+          if (this.board[this.yPosition + row][newXPosition]) {
             return true;
           }
         }

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -78,6 +78,11 @@ export class TetrisGame {
     // ゲームボードの初期位置設定 GAME_SETTINGSを直接変更することを防ぐために、クラスプロパティとしてxPositionとyPositionを使用。
     this.xPosition = GAME_SETTINGS.START_X_POSITION;
     this.yPosition = GAME_SETTINGS.START_Y_POSITION;
+
+    // キーボードイベントのリスナーを追加
+    document.addEventListener("keydown", (event) =>
+      this.controlTetromino(event)
+    );
   }
 
   /**
@@ -194,6 +199,70 @@ export class TetrisGame {
       this.xPosition = GAME_SETTINGS.START_X_POSITION;
       this.yPosition = GAME_SETTINGS.START_Y_POSITION;
     }
+  }
+
+  /**
+   * テトリスブロックを左右に移動させる
+   *
+   * @param {KeyboardEvent} event - キーボードイベント
+   * @returns {void}
+   */
+  controlTetromino(event) {
+    if (event.key === "ArrowLeft") {
+      this.moveTetrominoLeft();
+    } else if (event.key === "ArrowRight") {
+      this.moveTetrominoRight();
+    }
+  }
+
+  /**
+   * テトリスブロックを左に移動させる
+   * @returns {void}
+   */
+  moveTetrominoLeft() {
+    if (this.xPosition > 0 && !this.isTetrominoAtSides("left")) {
+      this.xPosition--;
+    }
+  }
+
+  /**
+   * テトリスブロックを右に移動させる
+   * @returns {void}
+   */
+  moveTetrominoRight() {
+    if (
+      this.xPosition + this.currentTetromino.shape[0].length <
+        GAME_SETTINGS.BOARD_COLUMNS &&
+      !this.isTetrominoAtSides("right")
+    ) {
+      this.xPosition++;
+    }
+  }
+
+  /**
+   * テトリスブロックが左右に移動できるかどうかを判定する
+   * @param {string} direction - 移動方向 ('left' または 'right')
+   * @returns {boolean} - 移動できない場合は`true`、移動できる場合は`false`
+   */
+  isTetrominoAtSides(direction) {
+    for (let row = 0; row < this.currentTetromino.shape.length; row++) {
+      for (let col = 0; col < this.currentTetromino.shape[row].length; col++) {
+        if (this.currentTetromino.shape[row][col]) {
+          const newXPosition =
+            direction === "left"
+              ? this.xPosition + col - 1
+              : this.xPosition + col + 1;
+          if (
+            newXPosition < 0 ||
+            newXPosition >= GAME_SETTINGS.BOARD_COLUMNS ||
+            this.board[this.yPosition + row][newXPosition]
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -8,6 +8,10 @@ export const GAME_SETTINGS = {
   BOARD_COLUMNS: 10,
   BOARD_ROWS: 20,
   BLOCK_SIZE: 30,
+  ARROW_LEFT: "ArrowLeft",
+  ARROW_RIGHT: "ArrowRight",
+  DIERCTION_LEFT: "left",
+  DIRECTION_RIGHT: "right",
 };
 
 /**
@@ -83,6 +87,14 @@ export class TetrisGame {
     document.addEventListener("keydown", (event) =>
       this.controlTetromino(event)
     );
+
+    // キーボードの矢印キー
+    this.arrowLeft = GAME_SETTINGS.ARROW_LEFT;
+    this.arrowRight = GAME_SETTINGS.ARROW_RIGHT;
+
+    // テトリスブロックの移動方向
+    this.directionLeft = GAME_SETTINGS.DIERCTION_LEFT;
+    this.directionRight = GAME_SETTINGS.DIRECTION_RIGHT;
   }
 
   /**
@@ -208,9 +220,9 @@ export class TetrisGame {
    * @returns {void}
    */
   controlTetromino(event) {
-    if (event.key === "ArrowLeft") {
+    if (event.key === this.arrowLeft) {
       this.moveTetrominoLeft();
-    } else if (event.key === "ArrowRight") {
+    } else if (event.key === this.arrowRight) {
       this.moveTetrominoRight();
     }
   }
@@ -220,7 +232,7 @@ export class TetrisGame {
    * @returns {void}
    */
   moveTetrominoLeft() {
-    if (!this.isTetrominoAtSides("left")) {
+    if (!this.isTetrominoAtSides(this.directionLeft)) {
       this.xPosition--;
 
       // 移動後にブロックが底に到達した場合、ブロックを固定して新しいブロックを生成
@@ -238,7 +250,7 @@ export class TetrisGame {
    * @returns {void}
    */
   moveTetrominoRight() {
-    if (!this.isTetrominoAtSides("right")) {
+    if (!this.isTetrominoAtSides(this.directionRight)) {
       this.xPosition++;
 
       // 移動後にブロックが底に到達した場合、ブロックを固定して新しいブロックを生成
@@ -262,7 +274,7 @@ export class TetrisGame {
         if (this.currentTetromino.shape[row][col]) {
           // 移動後のx位置を計算
           const newXPosition =
-            direction === "left"
+            direction === this.directionLeft
               ? this.xPosition + col - 1
               : this.xPosition + col + 1;
           // 左右に壁があるかを判定

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -218,35 +218,17 @@ export class TetrisGame {
    */
   controlTetromino(event) {
     if (event.key === this.arrowLeft) {
-      this.moveTetrominoLeft();
+      if (!this.isTetrominoAtSides(this.directionLeft)) {
+        this.xPosition--;
+      }
     } else if (event.key === this.arrowRight) {
-      this.moveTetrominoRight();
-    }
-  }
-
-  /**
-   * テトリスブロックを左に移動させる
-   * @returns {void}
-   */
-  moveTetrominoLeft() {
-    if (!this.isTetrominoAtSides(this.directionLeft)) {
-      this.xPosition--;
-      if (this.isTetrominoAtBottom()) {
-        this.freezeAndGenerateTetromino();
+      if (!this.isTetrominoAtSides(this.directionRight)) {
+        this.xPosition++;
       }
     }
-  }
-
-  /**
-   * テトリスブロックを右に移動させる
-   * @returns {void}
-   */
-  moveTetrominoRight() {
-    if (!this.isTetrominoAtSides(this.directionRight)) {
-      this.xPosition++;
-      if (this.isTetrominoAtBottom()) {
-        this.freezeAndGenerateTetromino();
-      }
+    // 移動後のブロックが底に到達した場合は固定して新しいブロックを生成
+    if (this.isTetrominoAtBottom()) {
+      this.freezeAndGenerateTetromino();
     }
   }
 

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -222,6 +222,14 @@ export class TetrisGame {
   moveTetrominoLeft() {
     if (!this.isTetrominoAtSides("left")) {
       this.xPosition--;
+
+      // 移動後にブロックが底に到達した場合、ブロックを固定して新しいブロックを生成
+      if (this.isTetrominoAtBottom()) {
+        this.freezeTetromino();
+        this.currentTetromino = this.generateTetromino();
+        this.xPosition = GAME_SETTINGS.START_X_POSITION;
+        this.yPosition = GAME_SETTINGS.START_Y_POSITION;
+      }
     }
   }
 
@@ -232,6 +240,14 @@ export class TetrisGame {
   moveTetrominoRight() {
     if (!this.isTetrominoAtSides("right")) {
       this.xPosition++;
+
+      // 移動後にブロックが底に到達した場合、ブロックを固定して新しいブロックを生成
+      if (this.isTetrominoAtBottom()) {
+        this.freezeTetromino();
+        this.currentTetromino = this.generateTetromino();
+        this.xPosition = GAME_SETTINGS.START_X_POSITION;
+        this.yPosition = GAME_SETTINGS.START_Y_POSITION;
+      }
     }
   }
 


### PR DESCRIPTION
## 概要
落下中のミノを、キーボードの矢印キーを使用して左右に移動させる処理を書きました。

## 確認事項
矢印キーを使用して左右に移動できるか
ボードの左端、右端を越えて移動できないようになっているか
左右にミノがあれば移動できないようになっているか
JSDocの記述に問題がないか

Closes #3 