### PR TITLE
feat: ミノを右回転させる機能

### DIFF
--- a/src/game/app.js
+++ b/src/game/app.js
@@ -270,19 +270,28 @@ export class TetrisGame {
       this.currentTetromino.shape.map((row) => row[index]).reverse()
     );
 
-    // 回転後のブロックがボードの範囲外にある場合はX軸の位置を調整
+    // 壁を越えないように調整
     let offsetX = 0;
     while (
       this.isTetrominoOutOfBounds(rotatedShape, this.xPosition + offsetX)
     ) {
       offsetX += this.xPosition > 0 ? -1 : 1;
+      if (Math.abs(offsetX) > rotatedShape[0].length) {
+        // 回転後の形が収まらない場合は回転をキャンセル
+        return;
+      }
     }
 
-    // 回転後のブロックが他のブロックと重なる場合はX軸の位置を調整
-    if (this.isTetrominoAtSides(GAME_SETTINGS.DIRECTION_RIGHT)) {
-      this.xPosition -= 1;
-    } else if (this.isTetrominoAtSides(GAME_SETTINGS.DIRECTION_LEFT)) {
-      this.xPosition += 1;
+    // ミノが他のブロックと重ならないように調整
+    if (
+      this.isTetrominoOverlapping(
+        rotatedShape,
+        this.xPosition + offsetX,
+        this.yPosition
+      )
+    ) {
+      // 回転に必要な空間がない場合は回転処理をキャンセル
+      return;
     }
 
     this.currentTetromino.shape = rotatedShape;
@@ -301,6 +310,26 @@ export class TetrisGame {
         if (cell) {
           const x = xPosition + colIndex;
           return x < 0 || x >= this.board[0].length;
+        }
+        return false;
+      })
+    );
+  }
+
+  /**
+   * 回転後のテトリスブロックが他のブロックと重なるかどうかを判定する
+   * @param {Array} shape - テトリスブロックの形状
+   * @param {number} xPosition - テトリスブロックのx位置
+   * @param {number} yPosition - テトリスブロックのy位置
+   * @returns {boolean} - ブロックが重なる場合は`true`、そうでない場合は`false`
+   */
+  isTetrominoOverlapping(shape, xPosition, yPosition) {
+    return shape.some((row, rowIndex) =>
+      row.some((cell, colIndex) => {
+        if (cell) {
+          const x = xPosition + colIndex;
+          const y = yPosition + rowIndex;
+          return this.board[y] && this.board[y][x];
         }
         return false;
       })

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -270,12 +270,19 @@ export class TetrisGame {
       this.currentTetromino.shape.map((row) => row[index]).reverse()
     );
 
-    // 壁を越えないように調整
+    // 回転後のブロックがボードの範囲外にある場合はX軸の位置を調整
     let offsetX = 0;
     while (
       this.isTetrominoOutOfBounds(rotatedShape, this.xPosition + offsetX)
     ) {
       offsetX += this.xPosition > 0 ? -1 : 1;
+    }
+
+    // 回転後のブロックが他のブロックと重なる場合はX軸の位置を調整
+    if (this.isTetrominoAtSides(GAME_SETTINGS.DIRECTION_RIGHT)) {
+      this.xPosition -= 1;
+    } else if (this.isTetrominoAtSides(GAME_SETTINGS.DIRECTION_LEFT)) {
+      this.xPosition += 1;
     }
 
     this.currentTetromino.shape = rotatedShape;

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -285,7 +285,7 @@ export class TetrisGame {
   /**
    * 回転後のテトリスブロックがボードの範囲外にあるかどうかを判定する
    * @param {Array} shape - テトリスブロックの形状
-   * @param {number} xPosition - 回転後のテトリスブロックのx座標
+   * @param {number} xPosition - テトリスブロックのx位置
    * @returns {boolean} - ブロックが範囲外にある場合は`true`、そうでない場合は`false`
    * */
   isTetrominoOutOfBounds(shape, xPosition) {

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -10,6 +10,7 @@ export const GAME_SETTINGS = {
   BLOCK_SIZE: 30,
   ARROW_LEFT: "ArrowLeft",
   ARROW_RIGHT: "ArrowRight",
+  ARROW_UP: "ArrowUp",
   ARROW_DOWN: "ArrowDown",
   SPACE_KEY: " ",
   DIRECTION_LEFT: "left",
@@ -50,7 +51,15 @@ export class TetrisGame {
     );
 
     this.tetrominoes = [
-      { shape: [[1, 1, 1, 1]], color: GAME_SETTINGS.COLORS.I }, // I型
+      {
+        shape: [
+          [0, 0, 0, 0],
+          [1, 1, 1, 1],
+          [0, 0, 0, 0],
+          [0, 0, 0, 0],
+        ],
+        color: GAME_SETTINGS.COLORS.I,
+      }, // I型
       {
         shape: [
           [1, 1],
@@ -62,6 +71,7 @@ export class TetrisGame {
         shape: [
           [1, 1, 0],
           [0, 1, 1],
+          [0, 0, 0],
         ],
         color: GAME_SETTINGS.COLORS.Z,
       }, // Z型
@@ -69,6 +79,7 @@ export class TetrisGame {
         shape: [
           [0, 1, 1],
           [1, 1, 0],
+          [0, 0, 0],
         ],
         color: GAME_SETTINGS.COLORS.S,
       }, // S型
@@ -76,6 +87,7 @@ export class TetrisGame {
         shape: [
           [1, 0, 0],
           [1, 1, 1],
+          [0, 0, 0],
         ],
         color: GAME_SETTINGS.COLORS.J,
       }, // J型
@@ -83,6 +95,7 @@ export class TetrisGame {
         shape: [
           [0, 0, 1],
           [1, 1, 1],
+          [0, 0, 0],
         ],
         color: GAME_SETTINGS.COLORS.L,
       }, // L型
@@ -90,6 +103,7 @@ export class TetrisGame {
         shape: [
           [0, 1, 0],
           [1, 1, 1],
+          [0, 0, 0],
         ],
         color: GAME_SETTINGS.COLORS.T,
       }, // T型
@@ -247,6 +261,46 @@ export class TetrisGame {
   }
 
   /**
+   * テトリスブロックを90度時計回りに回転させる
+   *
+   * @returns {void}
+   */
+  rotateTetromino() {
+    const rotatedShape = this.currentTetromino.shape[0].map((_, index) =>
+      this.currentTetromino.shape.map((row) => row[index]).reverse()
+    );
+
+    // 壁を越えないように調整
+    let offsetX = 0;
+    while (
+      this.isTetrominoOutOfBounds(rotatedShape, this.xPosition + offsetX)
+    ) {
+      offsetX += this.xPosition > 0 ? -1 : 1;
+    }
+
+    this.currentTetromino.shape = rotatedShape;
+    this.xPosition += offsetX;
+  }
+
+  /**
+   * 回転後のテトリスブロックがボードの範囲外にあるかどうかを判定する
+   * @param {Array} shape - テトリスブロックの形状
+   * @param {number} xPosition - 回転後のテトリスブロックのx座標
+   * @returns {boolean} - ブロックが範囲外にある場合は`true`、そうでない場合は`false`
+   * */
+  isTetrominoOutOfBounds(shape, xPosition) {
+    return shape.some((row) =>
+      row.some((cell, colIndex) => {
+        if (cell) {
+          const x = xPosition + colIndex;
+          return x < 0 || x >= this.board[0].length;
+        }
+        return false;
+      })
+    );
+  }
+
+  /**
    * キーを使用したテトリスブロックの操作
    *
    * @param {KeyboardEvent} event - キーボードイベント
@@ -267,6 +321,8 @@ export class TetrisGame {
       while (!this.isTetrominoAtBottom()) {
         this.yPosition++;
       }
+    } else if (event.key === GAME_SETTINGS.ARROW_UP) {
+      this.rotateTetromino();
     }
     // 移動後のブロックが底に到達した場合は固定して新しいブロックを生成
     if (this.isTetrominoAtBottom()) {


### PR DESCRIPTION
## 概要
以下のように実装・変更を加えました。

・ミノを右に90度回転させる処理
・ミノを回転させたときにボードからはみ出る場合、または左右に既存ミノがある場合にX軸の位置を調整する処理
・O型以外のミノの配列に0のみの行を1～3行追加

ミノの行列の中央を軸にすることで、回転時も配置が崩れにくくなるため、このような変更を加えました。
## 確認事項
ミノを回転することができるか
ボードを越えてミノを回転できないようになっているか
ミノの配列について問題はないか

Closes #13