### PR TITLE
次に操作するミノを表示する機能

### DIFF
--- a/src/game/app.js
+++ b/src/game/app.js
@@ -110,6 +110,7 @@ export class TetrisGame {
     ];
 
     this.currentTetromino = this.generateTetromino();
+    this.nextTetromino = this.generateTetromino();
     this.lastFallTime = 0;
 
     // ゲームスコアの初期化
@@ -159,6 +160,7 @@ export class TetrisGame {
     this.clearAndUpdateScore();
     this.drawBoard();
     this.drawTetromino();
+    this.drawNextTetromino();
     requestAnimationFrame(this.gameLoop.bind(this)); // コンテキストを維持
   }
 
@@ -236,6 +238,57 @@ export class TetrisGame {
         }
       }
     }
+  }
+
+  /**
+   * 次のテトリミノを描画する
+   *
+   * @returns {void}
+   */
+  drawNextTetromino() {
+    const nextTetrominoCanvas = document.getElementById("next-tetromino");
+    const context = nextTetrominoCanvas.getContext("2d");
+    const blockSize = GAME_SETTINGS.BLOCK_SIZE;
+
+    // キャンバスをクリア
+    context.clearRect(
+      0,
+      0,
+      nextTetrominoCanvas.width,
+      nextTetrominoCanvas.height
+    );
+
+    // O型とI型以外のミノの場合、X軸とY軸を1増やす
+    let offsetX = 0;
+    let offsetY = 0;
+    if (
+      this.nextTetromino.color !== GAME_SETTINGS.COLORS.O &&
+      this.nextTetromino.color !== GAME_SETTINGS.COLORS.I
+    ) {
+      offsetX = 1;
+      offsetY = 1;
+    }
+
+    // 次のテトリミノを描画
+    this.nextTetromino.shape.forEach((row, y) => {
+      row.forEach((value, x) => {
+        if (value) {
+          context.fillStyle = this.nextTetromino.color;
+          context.fillRect(
+            (x + offsetX) * blockSize,
+            (y + offsetY) * blockSize,
+            blockSize,
+            blockSize
+          );
+          context.strokeRect(
+            (x + offsetX) * blockSize,
+            (y + offsetY) * blockSize,
+            blockSize,
+            blockSize
+          );
+        }
+      });
+    });
   }
 
   /**
@@ -438,9 +491,11 @@ export class TetrisGame {
    */
   freezeAndGenerateTetromino() {
     this.freezeTetromino();
-    this.currentTetromino = this.generateTetromino();
+    this.currentTetromino = this.nextTetromino;
+    this.nextTetromino = this.generateTetromino();
     this.xPosition = GAME_SETTINGS.START_X_POSITION;
     this.yPosition = GAME_SETTINGS.START_Y_POSITION;
+    this.drawNextTetromino(); // 次のテトリミノを描画
   }
 
   /**

--- a/src/game/app.js
+++ b/src/game/app.js
@@ -258,13 +258,10 @@ export class TetrisGame {
       nextTetrominoCanvas.height
     );
 
-    // O型とI型以外のミノの場合、X軸とY軸を1増やす
+    // I型以外のミノの場合、X軸とY軸を1増やす
     let offsetX = 0;
     let offsetY = 0;
-    if (
-      this.nextTetromino.color !== GAME_SETTINGS.COLORS.O &&
-      this.nextTetromino.color !== GAME_SETTINGS.COLORS.I
-    ) {
+    if (this.nextTetromino.color !== GAME_SETTINGS.COLORS.I) {
       offsetX = 1;
       offsetY = 1;
     }

--- a/src/pages/game.js
+++ b/src/pages/game.js
@@ -19,6 +19,10 @@ export function renderGamePage() {
           <button id="backToTopButton">TOP画面へ</button>
         </div>
         <canvas id="tetris-board" width="300" height="600"></canvas>
+        <div class="next-tetromino mt-2">
+          <h3>NEXT</h3>
+          <canvas id="next-tetromino" width="120" height="120"></canvas>
+        </div>
       </div>
     </div>
   `;


### PR DESCRIPTION
## 概要
以下を実装しました。
・新規ボード
・そのボードに次に操作するミノを表示する処理

## 確認事項
・開始直後にミノが2つ生成され、別々のボードに表示されているか
・ミノが固定されたとき、操作対象が2番目に表示されたミノに切り替わっているか
・新規ボード内でミノが表示されない、ボードを越えて表示されることがないか

※2つ目のコミットメッセージの一部を以下のように読み替えてください
**I型のミノ → I型以外のミノ**